### PR TITLE
fixing README to include cloning repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ Simply clone the repository, open a terminal window, type:
 
 ::
 
-    cd /path/to/my/repo
+    git clone https://github.com/tabakg/potapov_interpolation
+    cd potapov_interpolation
     python setup.py install
 
 Files


### PR DESCRIPTION
This is a quick change to fix the readme to instruct the user to clone, cd, and then install. The original command specified /path/to/my/repo :)
