### PR TITLE
fix #11 2nd and #12. Handle non converged muller

### DIFF
--- a/Potapov_Code/Time_Delay_Network.py
+++ b/Potapov_Code/Time_Delay_Network.py
@@ -119,7 +119,7 @@ class Time_Delay_Network():
         '''Generate the roots given the denominator of the transfer function.
 
         '''
-        self.roots = Roots.get_roots_rect(self.T_denom,self.Tp_denom,
+        ret, self.roots = Roots.get_roots_rect(self.T_denom,self.Tp_denom,
             -self.max_linewidth/2.,self.center_freq,
             self.max_linewidth/2.,self.max_freq,N=self.N)
         return

--- a/Potapov_Code/tests/tests_Roots.py
+++ b/Potapov_Code/tests/tests_Roots.py
@@ -15,6 +15,25 @@ import scipy.constants as consts
 import matplotlib.pyplot as plt
 import time
 
+def get_root_bounds(roots):
+  x_lmt = [None,None]
+  y_lmt = [None,None]
+  for root in roots:
+    if x_lmt[0] is None or x_lmt[0]>root.real:
+      x_lmt[0] = root.real
+    if x_lmt[1] is None or x_lmt[1]<root.real:
+      x_lmt[1] = root.real
+    if y_lmt[0] is None or y_lmt[0]>root.imag:
+      y_lmt[0] = root.imag
+    if y_lmt[1] is None or y_lmt[1]<root.imag:
+      y_lmt[1] = root.imag
+  return x_lmt, y_lmt
+
+def almost_equal(el1,el2,eps=1e-7):
+    if abs(el1 - el2) < eps:
+        return True
+    else: return False  
+
 def two_sets_almost_equal(S1,S2,eps=1e-7):
     '''
     Tests if two iterables have the same elements up to some tolerance eps.
@@ -29,16 +48,11 @@ def two_sets_almost_equal(S1,S2,eps=1e-7):
     if len(S1) != len(S2):
         return False
 
-    def almost_equal(el1,el2):
-        if abs(el1 - el2) < eps:
-            return True
-        else: return False
-
     ran2 = range(len(S2))
     for i in range(len(S1)):
         found_match = False
         for j in ran2:
-            if almost_equal(S1[i],S2[j]):
+            if almost_equal(S1[i],S2[j],eps):
                 found_match = True
                 ran2.remove(j)
                 break
@@ -59,9 +73,10 @@ def test_Roots_1():
     width = 5.*np.pi-1e-5
     height = 5.*np.pi-1e-5
 
-    roots = np.asarray(Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N))
+    ret, retRoots = Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N)
+    roots = np.asarray(retRoots)
     roots_inside_boundary = Roots.inside_boundary(roots,x_cent,y_cent,width,height)
-    two_sets_almost_equal(np.asarray(roots_inside_boundary)/np.pi,
+    print two_sets_almost_equal(np.asarray(roots_inside_boundary)/np.pi,
         [-4.,-3.,-2.,-1.,-0.,1.,2.,3.,4.] )
 
 def test_Roots_2():
@@ -76,13 +91,77 @@ def test_Roots_2():
     width = 5.*np.pi+1e-5
     height = 5.*np.pi+1e-5
 
-    roots = np.asarray(Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N))
+    ret, retRoots = Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N)
+    roots = np.asarray(retRoots)
     roots_inside_boundary = Roots.inside_boundary(roots,x_cent,y_cent,width,height)
-    two_sets_almost_equal(np.asarray(roots_inside_boundary)/np.pi,
+    print two_sets_almost_equal(np.asarray(roots_inside_boundary)/np.pi,
         [-5.,-4.,-3.,-2.,-1.,-0.,1.,2.,3.,4.,5.] )
 
+def test_Poly_Roots(N, printRoots=False, printPolys=False, printParams=False, doubleOnWarning=False):
+    print "N=" + str(N)
 
+    coeff = []
+    for n in range(N):
+      coeff.append((n+1)*1.0+(n+1)*1.0j)
+    roots_numpy = np.roots(coeff)
+    bnds = get_root_bounds(roots_numpy)
+
+    poly = np.poly1d(coeff)
+    poly_diff = np.polyder(poly)
+    N = 5000
+    max_steps = 5
+    f = lambda z: poly(z)
+    fp = lambda z: poly_diff(z)
+    width = (bnds[0][1]-bnds[0][0])/2.
+    height = (bnds[1][1]-bnds[1][0])/2.
+    x_cent = bnds[0][0] + width
+    y_cent = bnds[1][0] + height
+    width += 0.1
+    height += 0.1
+    
+    if printPolys:
+        print poly
+        print poly_diff
+
+    ret = -1
+    while ret==-1 or (doubleOnWarning and ret!=0):
+        if ret == 1:
+            N *= 2
+        elif ret == 2:
+            max_steps *= 2
+        if printParams:
+            print "x_cent:" + str(x_cent)
+            print "y_cent:" + str(y_cent)
+            print "width:" + str(width)
+            print "height:" + str(height)
+            print "N:" + str(N)
+            print "max_steps:" + str(max_steps)
+        ret, roots_gil = Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N,max_steps=max_steps,verbose=True)
+    roots_gil = np.asarray(roots_gil)
+    roots_gil = Roots.inside_boundary(roots_gil,x_cent,y_cent,width,height)
+
+    print "\t" + str(len(roots_numpy)) + " numpy roots"
+    print "\t" + str(len(roots_gil)) + " gil roots"
+    common = 0
+    for root_numpy in roots_numpy:
+        for root_gil in roots_gil:
+            if almost_equal(root_numpy, root_gil,eps=1e-5):
+                common += 1
+                break
+    print "\t" + str(common) + " common roots"
+
+    if printRoots:
+        for root in sorted(roots_numpy):
+          print str(root) + "  \t" + str(f(root))
+        print
+        for root in sorted(roots_gil):
+          print str(root) + "  \t" + str(f(root))
+
+def test_Roots_3(printRoots=False, printPolys=False, printParams=False, doubleOnWarning=False):
+    for N in range(2,51):
+        test_Poly_Roots(N,printRoots,printPolys,printParams,doubleOnWarning)
 
 if __name__ == "__main__":
     test_Roots_1()
     test_Roots_2()
+    test_Roots_3()

--- a/Potapov_Code/tests/tests_Roots.py
+++ b/Potapov_Code/tests/tests_Roots.py
@@ -98,7 +98,7 @@ def test_Roots_2():
         [-5.,-4.,-3.,-2.,-1.,-0.,1.,2.,3.,4.,5.] )
 
 def test_Poly_Roots(N, printRoots=False, printPolys=False, printParams=False, doubleOnWarning=False):
-    print "N=" + str(N)
+    print "\nN=" + str(N)
 
     coeff = []
     for n in range(N):
@@ -125,9 +125,10 @@ def test_Poly_Roots(N, printRoots=False, printPolys=False, printParams=False, do
 
     ret = -1
     while ret==-1 or (doubleOnWarning and ret!=0):
-        if ret == 1:
+        # Doubling is for test purposes.
+        if ret & Roots.warn_imprecise_roots:
             N *= 2
-        elif ret == 2:
+        elif ret & Roots.warn_max_steps_exceeded:
             max_steps *= 2
         if printParams:
             print "x_cent:" + str(x_cent)
@@ -136,7 +137,7 @@ def test_Poly_Roots(N, printRoots=False, printPolys=False, printParams=False, do
             print "height:" + str(height)
             print "N:" + str(N)
             print "max_steps:" + str(max_steps)
-        ret, roots_gil = Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N,max_steps=max_steps,verbose=True)
+        ret, roots_gil = Roots.get_roots_rect(f,fp,x_cent,y_cent,width,height,N,max_steps=max_steps,verbose=False,summary=True)
     roots_gil = np.asarray(roots_gil)
     roots_gil = Roots.inside_boundary(roots_gil,x_cent,y_cent,width,height)
 


### PR DESCRIPTION
When muller fails to converge spurious roots can be returned. There is a bit of work in tidying up the warning reporting so the actual issue fixed may be slightly obscured, so I'll give a description here.

The problem was that spurious roots were being returned. This happened when the muller failed to find convergence after N. In this case the current value of x was just returned. As can be appreciated by running the poly test prior to fix (try for N=11) some of these returned values were far from being roots.

The fix is to ignore the returned values when the muller fails to converge and issue a warning instead. The muller has been extended to returning a warning boolean converged status, so this case can be handled in the client.